### PR TITLE
feat(ui): mobile-first header/sidebar with drawer behavior and inline header search

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -16,11 +16,11 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           className={cn(
             "flex-1 transition-all duration-300 ease-in-out",
             isCollapsed
-              ? "ml-[70px] w-[calc(100%-70px)]"
-              : "ml-64 w-[calc(100%-256px)]"
+              ? "md:ml-[70px]"
+              : "md:ml-64"
           )}
         >
-          <div className="container mx-auto p-6">{children}</div>
+          <div className="container mx-auto p-4 md:p-6">{children}</div>
         </main>
       </div>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { QueryProvider } from "@/providers/query-provider"
 import { AuthProvider } from "@/providers/auth-provider"
 import { ThemeProvider } from '@/components/theme/theme-provider'
 import { AppProvider } from "@/contexts/app-context"
-import { Header } from "@/components/header"
+import { Header } from "@/components/header/header"
 
 const inter = Inter({subsets: ['latin']})
 

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -7,8 +7,9 @@ import { AppRoutes } from "@/constants/routes"
 import { UserNav } from "@/components/header/user-nav"
 import { ThemeToggle } from "@/components/theme/theme-toggle"
 import { Button } from "@/components/ui/button"
-import { Menu } from "lucide-react"
+import { Bell, Menu } from "lucide-react"
 import { useApp } from "@/contexts/app-context"
+import { Badge } from "@/components/ui/badge"
 
 export function Header() {
   const { data: session } = useSession()
@@ -16,7 +17,7 @@ export function Header() {
 
   return (
     <header className="fixed top-0 left-0 right-0 h-16 border-b bg-background z-40">
-      <div className="h-full px-4 md:px-6 flex items-center justify-between">
+      <div className="h-full px-4 md:px-6 flex items-center justify-between gap-4">
         <div className="flex items-center gap-2">
           <Button
             variant="ghost"
@@ -25,7 +26,7 @@ export function Header() {
             onClick={toggleMobileSidebar}
             aria-label="Open sidebar menu"
           >
-            <Menu className="h-5 w-5" />
+            <Menu className="h-6 w-6" />
           </Button>
           <Link href={AppRoutes.DASHBOARD.HOME} className="flex items-center gap-2">
             <Image src="/logo.svg" alt="Nexus" width={24} height={24} className="rounded" />
@@ -33,17 +34,20 @@ export function Header() {
           </Link>
         </div>
 
-        <div className="flex items-center gap-4">
-          <ThemeToggle />
+        <div className="flex items-center gap-2 md:gap-4 min-w-0">
           {session?.user ? (
-            <UserNav user={session.user} />
+            <>
+              <Button variant="ghost" size="icon" className="relative h-10 w-10" aria-label="Notifications">
+                <Bell className="h-7 w-7" />
+                <Badge className="absolute -right-1 -top-1 h-5 min-w-5 px-1 text-[10px] leading-none">
+                  3
+                </Badge>
+              </Button>
+
+              <UserNav user={session.user} />
+            </>
           ) : (
-            <Link
-              href={AppRoutes.AUTH.LOGIN}
-              className="text-sm font-medium hover:text-foreground transition-colors"
-            >
-              Sign in
-            </Link>
+            <ThemeToggle />
           )}
         </div>
       </div>

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -16,12 +16,12 @@ export function Header() {
 
   return (
     <header className="fixed top-0 left-0 right-0 h-16 border-b bg-background z-40">
-      <div className="h-full px-6 flex items-center justify-between">
+      <div className="h-full px-4 md:px-6 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Button
             variant="ghost"
             size="icon"
-            className="md:hidden"
+            className="-ml-2 md:hidden"
             onClick={toggleMobileSidebar}
             aria-label="Open sidebar menu"
           >

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -6,17 +6,32 @@ import { useSession } from "next-auth/react"
 import { AppRoutes } from "@/constants/routes"
 import { UserNav } from "@/components/header/user-nav"
 import { ThemeToggle } from "@/components/theme/theme-toggle"
+import { Button } from "@/components/ui/button"
+import { Menu } from "lucide-react"
+import { useApp } from "@/contexts/app-context"
 
 export function Header() {
   const { data: session } = useSession()
+  const { toggleMobileSidebar } = useApp()
 
   return (
     <header className="fixed top-0 left-0 right-0 h-16 border-b bg-background z-40">
       <div className="h-full px-6 flex items-center justify-between">
-        <Link href={AppRoutes.DASHBOARD.HOME} className="flex items-center gap-2">
-          <Image src="/logo.svg" alt="Nexus" width={24} height={24} className="rounded" />
-          <span className="text-sm font-medium">Nexus</span>
-        </Link>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="md:hidden"
+            onClick={toggleMobileSidebar}
+            aria-label="Open sidebar menu"
+          >
+            <Menu className="h-5 w-5" />
+          </Button>
+          <Link href={AppRoutes.DASHBOARD.HOME} className="flex items-center gap-2">
+            <Image src="/logo.svg" alt="Nexus" width={24} height={24} className="rounded" />
+            <span className="text-sm font-medium">Nexus</span>
+          </Link>
+        </div>
 
         <div className="flex items-center gap-4">
           <ThemeToggle />

--- a/src/components/header/user-nav.tsx
+++ b/src/components/header/user-nav.tsx
@@ -10,7 +10,12 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { Button } from "@/components/ui/button"
 import { signOut } from "next-auth/react"
-import { UserCircle } from "lucide-react"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import Link from "next/link"
+import { AppRoutes } from "@/constants/routes"
+import { Moon, Plus, Settings, Sun } from "lucide-react"
+import { useTheme } from "next-themes"
+import { useEffect, useState } from "react"
 
 interface UserNavProps {
   user: {
@@ -21,11 +26,24 @@ interface UserNavProps {
 }
 
 export function UserNav({ user }: UserNavProps) {
+  const initials = getUserInitials(user.name)
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="relative h-8 w-8 rounded-full">
-          <UserCircle className="h-5 w-5" />
+        <Button variant="ghost" className="relative h-10 w-10 rounded-full">
+          <Avatar className="h-8 w-8">
+            <AvatarImage src={user.image ?? undefined} alt={user.name ?? "User avatar"} />
+            <AvatarFallback className="text-sm font-semibold">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-56" align="end" forceMount>
@@ -36,10 +54,41 @@ export function UserNav({ user }: UserNavProps) {
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
+        {mounted && (
+          <DropdownMenuItem onClick={() => setTheme(theme === "dark" ? "light" : "dark")}>
+            {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+            Toggle theme
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem asChild>
+          <Link href={AppRoutes.DASHBOARD.WORK_ITEMS}>
+            <Plus className="h-4 w-4" />
+            New task
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link href={AppRoutes.DASHBOARD.SETTINGS}>
+            <Settings className="h-4 w-4" />
+            Settings
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
         <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login" })}>
           Log out
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )
+}
+
+function getUserInitials(name?: string | null) {
+  if (!name) return "U"
+
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return "U"
+
+  const first = parts[0][0] ?? ""
+  const last = parts.length > 1 ? (parts[parts.length - 1][0] ?? "") : ""
+
+  return `${first}${last}`.toUpperCase()
 }

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -46,34 +46,58 @@ const SIDEBAR_ITEMS = [
 
 export function Sidebar() {
   const pathname = usePathname()
-  const {isCollapsed, toggleSidebar} = useApp()
+  const {isCollapsed, isMobileSidebarOpen, toggleSidebar, closeMobileSidebar} = useApp()
   
   const sidebarWidth = isCollapsed ? SIDEBAR_CONFIG.COLLAPSED_WIDTH : SIDEBAR_CONFIG.EXPANDED_WIDTH
   
   return (
-    <div className={cn(
-      `fixed ${SIDEBAR_CONFIG.TOP_OFFSET} left-0 ${SIDEBAR_CONFIG.HEIGHT} border-r bg-background`,
-      "transition-all duration-300 ease-in-out flex flex-col",
-      sidebarWidth
-    )}>
-      <NavigationSection
-        pathname={pathname}
-        isCollapsed={isCollapsed}
-      />
-      <CollapseToggleSection
-        isCollapsed={isCollapsed}
-        onToggle={toggleSidebar}
-      />
-    </div>
+    <>
+      {isMobileSidebarOpen && (
+        <button
+          type="button"
+          className="fixed inset-0 top-16 z-30 bg-black/50 md:hidden"
+          onClick={closeMobileSidebar}
+          aria-label="Close sidebar"
+        />
+      )}
+
+      <div className={cn(
+        `fixed ${SIDEBAR_CONFIG.TOP_OFFSET} left-0 ${SIDEBAR_CONFIG.HEIGHT} border-r bg-background z-40`,
+        "transition-transform duration-300 ease-in-out w-64 md:hidden",
+        isMobileSidebarOpen ? "translate-x-0" : "-translate-x-full"
+      )}>
+        <NavigationSection
+          pathname={pathname}
+          isCollapsed={false}
+          onItemSelect={closeMobileSidebar}
+        />
+      </div>
+
+      <div className={cn(
+        `fixed ${SIDEBAR_CONFIG.TOP_OFFSET} left-0 ${SIDEBAR_CONFIG.HEIGHT} border-r bg-background`,
+        "transition-all duration-300 ease-in-out md:flex flex-col hidden",
+        sidebarWidth
+      )}>
+        <NavigationSection
+          pathname={pathname}
+          isCollapsed={isCollapsed}
+        />
+        <CollapseToggleSection
+          isCollapsed={isCollapsed}
+          onToggle={toggleSidebar}
+        />
+      </div>
+    </>
   )
 }
 
 interface NavigationSectionProps {
   pathname: string
   isCollapsed: boolean
+  onItemSelect?: () => void
 }
 
-function NavigationSection({pathname, isCollapsed}: NavigationSectionProps) {
+function NavigationSection({pathname, isCollapsed, onItemSelect}: NavigationSectionProps) {
   return (
     <div className="flex-1 space-y-4 py-4">
       <div className="px-3 py-2">
@@ -84,6 +108,7 @@ function NavigationSection({pathname, isCollapsed}: NavigationSectionProps) {
               item={item}
               isActive={pathname === item.href}
               isCollapsed={isCollapsed}
+              onItemSelect={onItemSelect}
             />
           ))}
         </nav>
@@ -96,16 +121,17 @@ interface NavigationItemProps {
   item: typeof SIDEBAR_ITEMS[number]
   isActive: boolean
   isCollapsed: boolean
+  onItemSelect?: () => void
 }
 
-function NavigationItem({item, isActive, isCollapsed}: NavigationItemProps) {
+function NavigationItem({item, isActive, isCollapsed, onItemSelect}: NavigationItemProps) {
   const IconComponent = item.icon
   
   return (
     <TooltipProvider delayDuration={0}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Link href={item.href}>
+          <Link href={item.href} onClick={onItemSelect}>
             <Button
               variant={isActive ? "secondary" : "ghost"}
               className={cn(

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -52,18 +52,21 @@ export function Sidebar() {
   
   return (
     <>
-      {isMobileSidebarOpen && (
-        <button
-          type="button"
-          className="fixed inset-0 top-16 z-30 bg-black/50 md:hidden"
-          onClick={closeMobileSidebar}
-          aria-label="Close sidebar"
-        />
-      )}
+      <button
+        type="button"
+        className={cn(
+          "fixed inset-0 top-16 z-30 bg-black/40 backdrop-blur-[1px] md:hidden",
+          "transition-opacity duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
+          isMobileSidebarOpen ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
+        )}
+        onClick={closeMobileSidebar}
+        aria-label="Close sidebar"
+      />
 
       <div className={cn(
         `fixed ${SIDEBAR_CONFIG.TOP_OFFSET} left-0 ${SIDEBAR_CONFIG.HEIGHT} border-r bg-background z-40`,
-        "transition-transform duration-300 ease-in-out w-64 md:hidden",
+        "w-64 md:hidden overflow-hidden will-change-transform",
+        "transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
         isMobileSidebarOpen ? "translate-x-0" : "-translate-x-full"
       )}>
         <NavigationSection
@@ -75,7 +78,7 @@ export function Sidebar() {
 
       <div className={cn(
         `fixed ${SIDEBAR_CONFIG.TOP_OFFSET} left-0 ${SIDEBAR_CONFIG.HEIGHT} border-r bg-background`,
-        "transition-all duration-300 ease-in-out md:flex flex-col hidden",
+        "transition-all duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] md:flex flex-col hidden overflow-hidden",
         sidebarWidth
       )}>
         <NavigationSection
@@ -131,19 +134,28 @@ function NavigationItem({item, isActive, isCollapsed, onItemSelect}: NavigationI
     <TooltipProvider delayDuration={0}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Link href={item.href} onClick={onItemSelect}>
-            <Button
-              variant={isActive ? "secondary" : "ghost"}
-              className={cn(
-                "w-full justify-start",
-                isActive && "bg-muted",
-                isCollapsed && "justify-center px-2"
-              )}
-            >
+          <Button
+            asChild
+            variant={isActive ? "secondary" : "ghost"}
+            className={cn(
+              "w-full justify-start overflow-hidden transition-all duration-200",
+              "hover:translate-x-0.5 hover:bg-muted/80",
+              isActive && "bg-muted",
+              isCollapsed && "justify-center px-2"
+            )}
+          >
+            <Link href={item.href} onClick={onItemSelect}>
               <IconComponent className={cn("h-4 w-4", !isCollapsed && "mr-2")}/>
-              {!isCollapsed && <span>{item.title}</span>}
-            </Button>
-          </Link>
+              <span
+                className={cn(
+                  "truncate whitespace-nowrap transition-all duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
+                  isCollapsed ? "max-w-0 opacity-0 translate-x-1" : "max-w-[140px] opacity-100 translate-x-0"
+                )}
+              >
+                {item.title}
+              </span>
+            </Link>
+          </Button>
         </TooltipTrigger>
         {isCollapsed && (
           <TooltipContent side="right" className="pointer-events-none">
@@ -171,13 +183,20 @@ function CollapseToggleSection({isCollapsed, onToggle}: CollapseToggleSectionPro
             <Button
               variant="ghost"
               size="sm"
-              className="w-full flex items-center justify-center transition-all duration-300 ease-in-out"
+              className="w-full flex items-center justify-center transition-all duration-300 ease-out hover:bg-muted/70"
               onClick={onToggle}
             >
               <ChevronLeft
                 className={cn("h-4 w-4 transition-transform", isCollapsed && "rotate-180")}
               />
-              {!isCollapsed && <span className="ml-2">{tooltipText}</span>}
+              <span
+                className={cn(
+                  "ml-2 whitespace-nowrap overflow-hidden transition-all duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
+                  isCollapsed ? "max-w-0 opacity-0" : "max-w-[160px] opacity-100"
+                )}
+              >
+                {tooltipText}
+              </span>
             </Button>
           </TooltipTrigger>
           {isCollapsed && (

--- a/src/components/theme/theme-toggle.tsx
+++ b/src/components/theme/theme-toggle.tsx
@@ -20,12 +20,13 @@ export function ThemeToggle() {
     <Button
       variant="ghost"
       size="icon"
+      className="h-9 w-9"
       onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
     >
       {theme === 'dark' ? (
-        <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all"/>
+        <Sun className="h-[1.35rem] w-[1.35rem] rotate-0 scale-100 transition-all"/>
       ) : (
-        <Moon className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all"/>
+        <Moon className="h-[1.35rem] w-[1.35rem] rotate-0 scale-100 transition-all"/>
       )}
       <span className="sr-only">Toggle theme</span>
     </Button>

--- a/src/contexts/app-context.tsx
+++ b/src/contexts/app-context.tsx
@@ -5,8 +5,11 @@ import React, { createContext, useContext, useEffect, useState } from 'react'
 interface AppContextType {
   theme: 'light' | 'dark' | 'system'
   isCollapsed: boolean
+  isMobileSidebarOpen: boolean
   setTheme: (theme: 'light' | 'dark' | 'system') => void
   toggleSidebar: () => void
+  toggleMobileSidebar: () => void
+  closeMobileSidebar: () => void
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined)
@@ -25,6 +28,8 @@ export function AppProvider({children}: { children: React.ReactNode }) {
     }
     return false
   })
+
+  const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
   
   useEffect(() => {
     localStorage.setItem('theme', theme)
@@ -33,11 +38,31 @@ export function AppProvider({children}: { children: React.ReactNode }) {
   useEffect(() => {
     localStorage.setItem('sidebarCollapsed', String(isCollapsed))
   }, [isCollapsed])
+
+  useEffect(() => {
+    if (!isMobileSidebarOpen) return
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = ''
+    }
+  }, [isMobileSidebarOpen])
   
   const toggleSidebar = () => setIsCollapsed(prev => !prev)
+  const toggleMobileSidebar = () => setIsMobileSidebarOpen(prev => !prev)
+  const closeMobileSidebar = () => setIsMobileSidebarOpen(false)
   
   return (
-    <AppContext.Provider value={{theme, isCollapsed, setTheme, toggleSidebar}}>
+    <AppContext.Provider
+      value={{
+        theme,
+        isCollapsed,
+        isMobileSidebarOpen,
+        setTheme,
+        toggleSidebar,
+        toggleMobileSidebar,
+        closeMobileSidebar
+      }}
+    >
       {children}
     </AppContext.Provider>
   )


### PR DESCRIPTION
## Summary
This PR improves the dashboard shell with a mobile-first approach, focusing on sidebar behavior, header UX, and search interaction.

## Changes
- Reworked sidebar behavior for mobile:
    - Sidebar starts closed on mobile
    - Opens as a drawer/overlay (does not push main content)
    - Improved open/close transitions and interaction polish
- Kept desktop sidebar collapse behavior and smoothed collapse transitions
- Refined header layout/responsiveness:
    - Better mobile alignment and spacing
    - Updated icon sizing and avatar fallback (user initials when no image)
- Reorganized header actions by auth state:
    - Logged-in: search + notifications visible in header
    - User-specific actions remain in avatar dropdown
- Added inline header search component:
    - Extracted into dedicated component
    - Click on search icon expands input in header with animation
    - Search input clears whenever closed

## Why
- Fix mobile usability issues (content shifting, cramped navigation)
- Improve consistency between desktop and mobile navigation patterns
- Reduce header clutter while keeping key actions discoverable
- Prepare search UX for future integration with real results/actions

## Notes
- Existing lint issues outside this scope remain unchanged (`next-env.d.ts`, `use-toast.ts`).