### PR TITLE
feat: profile settings, sidebar refactor, and UI polish

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
+      },
+    ],
+  },
 }
 
 module.exports = nextConfig

--- a/src/actions/settings/index.ts
+++ b/src/actions/settings/index.ts
@@ -4,10 +4,35 @@ import { auth } from "@/auth"
 import { db } from "@/lib/db"
 import { revalidatePath } from "next/cache"
 import { AppRoutes } from "@/constants/routes"
+import { z } from "zod"
 
 type ActionResult<T = void> =
   | { success: true; data: T }
   | { success: false; error: string }
+
+const updateProfileSchema = z.object({
+  name: z.string().min(2, "Name must be at least 2 characters"),
+})
+
+export async function updateProfile(formData: FormData): Promise<ActionResult> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return { success: false, error: "Unauthorized" }
+  }
+
+  const parsed = updateProfileSchema.safeParse({ name: formData.get("name") })
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.errors[0].message }
+  }
+
+  await db.user.update({
+    where: { id: session.user.id },
+    data: { name: parsed.data.name.trim() },
+  })
+
+  revalidatePath(AppRoutes.DASHBOARD.SETTINGS)
+  return { success: true, data: undefined }
+}
 
 export async function clearAllData(): Promise<ActionResult> {
   const session = await auth()

--- a/src/app/(dashboard)/loading.tsx
+++ b/src/app/(dashboard)/loading.tsx
@@ -1,0 +1,67 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+function StatCardSkeleton() {
+  return (
+    <div className="rounded-lg border bg-card p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-8 w-8 rounded-full" />
+      </div>
+      <Skeleton className="h-7 w-12" />
+      <Skeleton className="h-3 w-36" />
+    </div>
+  )
+}
+
+function ChartCardSkeleton() {
+  return (
+    <div className="rounded-lg border bg-card p-6 space-y-4">
+      <Skeleton className="h-5 w-32" />
+      <Skeleton className="h-[200px] w-full rounded-md" />
+    </div>
+  )
+}
+
+function TableSkeleton() {
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="p-6 border-b">
+        <Skeleton className="h-5 w-32" />
+      </div>
+      <div className="divide-y">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 px-6 py-3">
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-5 w-20 rounded-full ml-auto" />
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default function OverviewLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Skeleton className="h-8 w-36" />
+        <Skeleton className="h-4 w-64" />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <StatCardSkeleton key={i} />
+        ))}
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <ChartCardSkeleton />
+        <ChartCardSkeleton />
+      </div>
+
+      <TableSkeleton />
+    </div>
+  )
+}

--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -1,9 +1,0 @@
-'use client'
-
-export default function ProfilePage() {
-  return (
-    <div className="space-y-6">
-      ProfilePage
-    </div>
-  )
-}

--- a/src/app/(dashboard)/projects/loading.tsx
+++ b/src/app/(dashboard)/projects/loading.tsx
@@ -1,0 +1,52 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+function ProjectCardSkeleton() {
+  return (
+    <div className="rounded-lg border border-l-4 border-l-muted bg-card p-4 space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3 flex-1">
+          <Skeleton className="h-8 w-8 rounded-md shrink-0" />
+          <div className="space-y-1.5 flex-1">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-3 w-64" />
+          </div>
+        </div>
+        <div className="flex gap-1">
+          <Skeleton className="h-7 w-7 rounded-md" />
+          <Skeleton className="h-7 w-7 rounded-md" />
+        </div>
+      </div>
+
+      <div className="space-y-5">
+        <Skeleton className="h-1.5 w-full rounded-full" />
+        <div className="flex gap-3">
+          <Skeleton className="h-3 w-12" />
+          <Skeleton className="h-3 w-10" />
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-3 w-8" />
+          <Skeleton className="h-3 w-8 ml-auto" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function ProjectsLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-4 w-44" />
+        </div>
+        <Skeleton className="h-9 w-32 rounded-md" />
+      </div>
+
+      <div className="space-y-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <ProjectCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -1,6 +1,7 @@
 import { Separator } from '@/components/ui/separator'
 import { DangerZone } from '@/components/settings/danger-zone'
 import { ProfileSettings } from '@/components/settings/profile-settings'
+import { ThemeSettings } from '@/components/settings/theme-settings'
 
 export default function SettingsPage() {
   return (
@@ -12,6 +13,8 @@ export default function SettingsPage() {
 
       <Separator />
       <ProfileSettings />
+      <Separator />
+      <ThemeSettings />
       <Separator />
       <DangerZone />
     </div>

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -1,5 +1,6 @@
 import { Separator } from '@/components/ui/separator'
 import { DangerZone } from '@/components/settings/danger-zone'
+import { ProfileSettings } from '@/components/settings/profile-settings'
 
 export default function SettingsPage() {
   return (
@@ -10,7 +11,8 @@ export default function SettingsPage() {
       </div>
 
       <Separator />
-
+      <ProfileSettings />
+      <Separator />
       <DangerZone />
     </div>
   )

--- a/src/app/(dashboard)/tasks/loading.tsx
+++ b/src/app/(dashboard)/tasks/loading.tsx
@@ -1,0 +1,37 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+function TaskCardSkeleton() {
+  return (
+    <div className="rounded-lg border bg-card p-4 flex flex-col gap-3 h-36">
+      <div className="flex-1 space-y-2">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-3 w-24 mt-1" />
+      </div>
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-5 w-20 rounded-full" />
+        <Skeleton className="h-4 w-16" />
+      </div>
+    </div>
+  )
+}
+
+export default function TasksLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-24" />
+          <Skeleton className="h-4 w-52" />
+        </div>
+        <Skeleton className="h-9 w-28 rounded-md" />
+      </div>
+
+      <div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <TaskCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -32,8 +32,11 @@ export const { handlers, auth, signIn } = NextAuth({
     }),
   ],
   callbacks: {
-    jwt({ token, user }) {
+    jwt({ token, user, trigger, session: sessionData }) {
       if (user) token.id = user.id
+      if (trigger === 'update' && sessionData?.name) {
+        token.name = sessionData.name as string
+      }
       return token
     },
     session({ session, token }) {

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -6,9 +6,9 @@ import { useSession } from "next-auth/react"
 import { AppRoutes } from "@/constants/routes"
 import { UserNav } from "@/components/header/user-nav"
 import { Button } from "@/components/ui/button"
-import { Bell, Menu } from "lucide-react"
+import { Menu } from "lucide-react"
 import { useApp } from "@/contexts/app-context"
-import { Badge } from "@/components/ui/badge"
+import { ThemeToggle } from "@/components/theme/theme-toggle"
 
 export function Header() {
   const { data: session, status } = useSession()
@@ -33,18 +33,10 @@ export function Header() {
           </Link>
         </div>
 
-        <div className="flex items-center gap-2 md:gap-4 min-w-0">
-          <Button variant="ghost" size="icon" className="relative h-10 w-10" aria-label="Notifications">
-            <Bell className="h-7 w-7" />
-            <Badge className="absolute -right-1 -top-1 h-5 min-w-5 px-1 text-[10px] leading-none">
-              3
-            </Badge>
-          </Button>
-          {status === 'loading' && (
-            <div className="h-10 w-10 rounded-full bg-muted animate-pulse" />
-          )}
-          {status === 'authenticated' && session?.user && <UserNav user={session.user} />}
-        </div>
+        {status === 'loading' && (
+          <div className="h-10 w-10 rounded-full bg-muted animate-pulse" />
+        )}
+        {status === 'authenticated' && session?.user && <UserNav user={session.user} />}
       </div>
     </header>
   )

--- a/src/components/header/user-nav.tsx
+++ b/src/components/header/user-nav.tsx
@@ -9,13 +9,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Button } from "@/components/ui/button"
+import { UserAvatar } from "@/components/ui/user-avatar"
 import { signOut } from "next-auth/react"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import Link from "next/link"
 import { AppRoutes } from "@/constants/routes"
-import { Moon, Plus, Settings, Sun } from "lucide-react"
-import { useTheme } from "next-themes"
-import { useEffect, useState } from "react"
+import { Plus, Settings } from "lucide-react"
 
 interface UserNavProps {
   user: {
@@ -26,24 +24,11 @@ interface UserNavProps {
 }
 
 export function UserNav({ user }: UserNavProps) {
-  const initials = getUserInitials(user.name)
-  const { theme, setTheme } = useTheme()
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
-
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="relative h-10 w-10 rounded-full">
-          <Avatar className="h-8 w-8">
-            <AvatarImage src={user.image ?? undefined} alt={user.name ?? "User avatar"} />
-            <AvatarFallback className="text-sm font-semibold">
-              {initials}
-            </AvatarFallback>
-          </Avatar>
+        <Button variant="ghost" className="relative h-10 w-10 rounded-full p-0">
+          <UserAvatar src={user.image} name={user.name ?? 'U'} size="md" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-56" align="end" forceMount>
@@ -54,12 +39,6 @@ export function UserNav({ user }: UserNavProps) {
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        {mounted && (
-          <DropdownMenuItem onClick={() => setTheme(theme === "dark" ? "light" : "dark")}>
-            {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
-            Toggle theme
-          </DropdownMenuItem>
-        )}
         <DropdownMenuItem asChild>
           <Link href={AppRoutes.DASHBOARD.TASKS}>
             <Plus className="h-4 w-4" />
@@ -79,16 +58,4 @@ export function UserNav({ user }: UserNavProps) {
       </DropdownMenuContent>
     </DropdownMenu>
   )
-}
-
-function getUserInitials(name?: string | null) {
-  if (!name) return "U"
-
-  const parts = name.trim().split(/\s+/).filter(Boolean)
-  if (parts.length === 0) return "U"
-
-  const first = parts[0][0] ?? ""
-  const last = parts.length > 1 ? (parts[parts.length - 1][0] ?? "") : ""
-
-  return `${first}${last}`.toUpperCase()
 }

--- a/src/components/overview/priority-distribution.tsx
+++ b/src/components/overview/priority-distribution.tsx
@@ -47,7 +47,7 @@ export function PriorityDistribution({ byPriority = {} }: PriorityDistributionPr
         ) : (
           <ChartContainer config={chartConfig} className="aspect-auto h-[240px] sm:h-[300px] w-full">
             <PieChart>
-              <ChartTooltip content={<ChartTooltipContent nameKey="priority" indicator="dot" />} />
+              <ChartTooltip content={<ChartTooltipContent nameKey="priority" indicator="dot" hideLabel />} />
               <Pie
                 data={data}
                 dataKey="value"

--- a/src/components/overview/tasks-by-status.tsx
+++ b/src/components/overview/tasks-by-status.tsx
@@ -2,7 +2,7 @@
 
 import { Bar, BarChart, CartesianGrid, Cell, XAxis, YAxis } from 'recharts'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from '@/components/ui/chart'
+import { ChartContainer, ChartTooltip, type ChartConfig } from '@/components/ui/chart'
 import { TASK_STATUS_COLORS, TASK_STATUS_NAMES } from "@/constants/task"
 import { BarChart2 } from 'lucide-react'
 
@@ -43,8 +43,26 @@ export function TasksByStatus({ byStatus }: TasksByStatusProps) {
               <CartesianGrid vertical={false} />
               <XAxis dataKey="label" tickLine={false} axisLine={false} />
               <YAxis tickLine={false} axisLine={false} allowDecimals={false} />
-              <ChartTooltip content={<ChartTooltipContent nameKey="status" indicator="dot" />} />
-              <Bar dataKey="value" radius={[4, 4, 0, 0]}>
+              <ChartTooltip
+                cursor={false}
+                content={({ payload }) => {
+                  if (!payload?.length) return null
+                  const item = payload[0]
+                  const status = item.payload.status as keyof typeof TASK_STATUS_COLORS
+                  const color = TASK_STATUS_COLORS[status]
+                  const label = TASK_STATUS_NAMES[status as keyof typeof TASK_STATUS_NAMES]
+                  return (
+                    <div className="rounded-lg border bg-background p-2 shadow-sm text-sm">
+                      <div className="flex items-center gap-2">
+                        <div className="h-2.5 w-2.5 rounded-full shrink-0" style={{ backgroundColor: color }} />
+                        <span className="text-muted-foreground">{label}</span>
+                        <span className="ml-auto font-medium">{String(item.value)}</span>
+                      </div>
+                    </div>
+                  )
+                }}
+              />
+              <Bar dataKey="value" radius={[4, 4, 0, 0]} activeBar={false}>
                 {data.map((entry) => (
                   <Cell
                     key={entry.status}

--- a/src/components/settings/profile-settings.tsx
+++ b/src/components/settings/profile-settings.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { useTransition, useState, useEffect } from 'react'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { UserAvatar } from '@/components/ui/user-avatar'
+import { updateProfile } from '@/actions/settings'
+
+export function ProfileSettings() {
+  const { data: session, update } = useSession()
+  const [name, setName] = useState('')
+  const [error, setError] = useState('')
+  const [saved, setSaved] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  useEffect(() => {
+    if (session?.user?.name) setName(session.user.name)
+  }, [session?.user?.name])
+
+  const isDirty = name !== (session?.user?.name ?? '')
+  const isValid = name.trim().length >= 2
+
+  function handleSave() {
+    setError('')
+    setSaved(false)
+    const formData = new FormData()
+    formData.set('name', name)
+
+    startTransition(async () => {
+      const result = await updateProfile(formData)
+      if (!result.success) {
+        setError(result.error)
+        return
+      }
+      await update({ name: name.trim() })
+      setSaved(true)
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">Profile</h2>
+        <p className="text-sm text-muted-foreground">Manage your personal information.</p>
+      </div>
+
+      <div className="flex items-start gap-5">
+        <UserAvatar src={session?.user?.image} name={name || session?.user?.name || 'U'} size="xl" />
+
+        <div className="flex-1 space-y-3">
+          <div className="space-y-1">
+            <Label htmlFor="profile-name">Name</Label>
+            <div className="flex gap-2">
+              <Input
+                id="profile-name"
+                value={name}
+                onChange={(e) => { setName(e.target.value); setSaved(false) }}
+                placeholder="Your name"
+                className="h-9"
+              />
+              <Button
+                onClick={handleSave}
+                disabled={isPending || !isDirty || !isValid}
+                size="sm"
+                className="h-9 shrink-0"
+              >
+                {isPending ? 'Saving…' : 'Save'}
+              </Button>
+            </div>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            {saved && <p className="text-sm text-emerald-600">Name updated.</p>}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="profile-email">Email</Label>
+            <Input
+              id="profile-email"
+              value={session?.user?.email ?? ''}
+              readOnly
+              disabled
+              className="h-9 cursor-not-allowed"
+            />
+            <p className="text-xs text-muted-foreground">Email cannot be changed.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/settings/theme-settings.tsx
+++ b/src/components/settings/theme-settings.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { useEffect, useState } from 'react'
+import { Moon, Sun, Monitor } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+const THEMES = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'system', label: 'System', icon: Monitor },
+] as const
+
+export function ThemeSettings() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">Theme</h2>
+        <p className="text-sm text-muted-foreground">Choose how Nexus looks for you.</p>
+      </div>
+
+      <div className="flex gap-3">
+        {THEMES.map(({ value, label, icon: Icon }) => (
+          <Button
+            key={value}
+            variant="outline"
+            className={cn(
+              "flex flex-col items-center gap-2 h-auto py-3 px-5",
+              mounted && theme === value && "border-foreground bg-muted"
+            )}
+            onClick={() => setTheme(value)}
+          >
+            <Icon className="h-4 w-4" />
+            <span className="text-xs">{label}</span>
+          </Button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/sidebar/collapse-toggle.tsx
+++ b/src/components/sidebar/collapse-toggle.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { ChevronLeft } from 'lucide-react'
+
+interface CollapseToggleProps {
+  isCollapsed: boolean
+  onToggle: () => void
+}
+
+export function CollapseToggle({ isCollapsed, onToggle }: CollapseToggleProps) {
+  const label = isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'
+
+  return (
+    <div className="p-1 border-t">
+      <TooltipProvider delayDuration={0}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full flex items-center justify-center transition-all duration-300 ease-out hover:bg-muted/70"
+              onClick={onToggle}
+            >
+              <ChevronLeft
+                className={cn('h-4 w-4 transition-transform', isCollapsed && 'rotate-180')}
+              />
+              <span
+                className={cn(
+                  'ml-2 whitespace-nowrap overflow-hidden transition-all duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]',
+                  isCollapsed ? 'max-w-0 opacity-0' : 'max-w-[160px] opacity-100'
+                )}
+              >
+                {label}
+              </span>
+            </Button>
+          </TooltipTrigger>
+          {isCollapsed && (
+            <TooltipContent side="right" className="pointer-events-none">
+              {label}
+            </TooltipContent>
+          )}
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  )
+}

--- a/src/components/sidebar/config.ts
+++ b/src/components/sidebar/config.ts
@@ -1,0 +1,26 @@
+import { LayoutDashboard, FolderKanban, ListTodo, Settings } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { AppRoutes } from '@/constants/routes'
+
+export const SIDEBAR_CONFIG = {
+  COLLAPSED_WIDTH: 'w-[70px]',
+  EXPANDED_WIDTH: 'w-64',
+  TOP_OFFSET: 'top-[64px]',
+  HEIGHT: 'h-[calc(100vh-64px)]',
+} as const
+
+export type NavItem = {
+  title: string
+  href: string
+  icon: LucideIcon
+}
+
+export const MAIN_NAV_ITEMS: NavItem[] = [
+  { title: 'Overview', href: AppRoutes.DASHBOARD.HOME, icon: LayoutDashboard },
+  { title: 'Projects', href: AppRoutes.DASHBOARD.PROJECTS, icon: FolderKanban },
+  { title: 'Tasks', href: AppRoutes.DASHBOARD.TASKS, icon: ListTodo },
+]
+
+export const BOTTOM_NAV_ITEMS: NavItem[] = [
+  { title: 'Settings', href: AppRoutes.DASHBOARD.SETTINGS, icon: Settings },
+]

--- a/src/components/sidebar/navigation-item.tsx
+++ b/src/components/sidebar/navigation-item.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import Link from 'next/link'
+import type { NavItem } from './config'
+
+interface NavigationItemProps {
+  item: NavItem
+  isActive: boolean
+  isCollapsed: boolean
+  onItemSelect?: () => void
+}
+
+export function NavigationItem({ item, isActive, isCollapsed, onItemSelect }: NavigationItemProps) {
+  const Icon = item.icon
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            asChild
+            variant={isActive ? 'secondary' : 'ghost'}
+            className={cn(
+              'w-full justify-start overflow-hidden transition-all duration-200',
+              'hover:translate-x-0.5 hover:bg-muted/80',
+              isActive && 'bg-muted',
+              isCollapsed && 'justify-center px-2 gap-0'
+            )}
+          >
+            <Link href={item.href} onClick={onItemSelect}>
+              <Icon className={cn('h-4 w-4', !isCollapsed && 'mr-2')} />
+              <span
+                className={cn(
+                  'truncate whitespace-nowrap transition-all duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]',
+                  isCollapsed
+                    ? 'max-w-0 opacity-0 translate-x-1'
+                    : 'max-w-[140px] opacity-100 translate-x-0'
+                )}
+              >
+                {item.title}
+              </span>
+            </Link>
+          </Button>
+        </TooltipTrigger>
+        {isCollapsed && (
+          <TooltipContent side="right" className="pointer-events-none">
+            {item.title}
+          </TooltipContent>
+        )}
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/src/components/sidebar/navigation-section.tsx
+++ b/src/components/sidebar/navigation-section.tsx
@@ -1,0 +1,43 @@
+import { NavigationItem } from './navigation-item'
+import { MAIN_NAV_ITEMS, BOTTOM_NAV_ITEMS } from './config'
+
+interface NavigationSectionProps {
+  pathname: string
+  isCollapsed: boolean
+  onItemSelect?: () => void
+}
+
+export function NavigationSection({ pathname, isCollapsed, onItemSelect }: NavigationSectionProps) {
+  return (
+    <div className="flex flex-col flex-1 py-4 overflow-hidden">
+      <div className="flex-1 px-3">
+        <nav className="space-y-1">
+          {MAIN_NAV_ITEMS.map((item) => (
+            <NavigationItem
+              key={item.href}
+              item={item}
+              isActive={pathname === item.href}
+              isCollapsed={isCollapsed}
+              onItemSelect={onItemSelect}
+            />
+          ))}
+        </nav>
+      </div>
+
+      <div className="px-3 pb-2">
+        <div className="h-px bg-border mb-3" />
+        <nav className="space-y-1">
+          {BOTTOM_NAV_ITEMS.map((item) => (
+            <NavigationItem
+              key={item.href}
+              item={item}
+              isActive={pathname === item.href}
+              isCollapsed={isCollapsed}
+              onItemSelect={onItemSelect}
+            />
+          ))}
+        </nav>
+      </div>
+    </div>
+  )
+}

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -1,211 +1,55 @@
 'use client'
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { usePathname } from "next/navigation"
-import Link from "next/link"
-import { AppRoutes } from '@/constants/routes'
-import { ChevronLeft, FolderKanban, KanbanSquare, LayoutDashboard, ListTodo, Settings, User } from "lucide-react"
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
-import { useApp } from "@/contexts/app-context"
-
-const SIDEBAR_CONFIG = {
-  COLLAPSED_WIDTH: 'w-[70px]',
-  EXPANDED_WIDTH: 'w-64',
-  TOP_OFFSET: 'top-[64px]',
-  HEIGHT: 'h-[calc(100vh-64px)]'
-} as const
-
-const SIDEBAR_ITEMS = [
-  {
-    title: "Overview",
-    href: AppRoutes.DASHBOARD.HOME,
-    icon: LayoutDashboard
-  },
-  {
-    title: "Projects",
-    href: AppRoutes.DASHBOARD.PROJECTS,
-    icon: FolderKanban
-  },
-  {
-    title: "Tasks",
-    href: AppRoutes.DASHBOARD.TASKS,
-    icon: ListTodo
-  },
-  {
-    title: "Profile",
-    href: AppRoutes.DASHBOARD.PROFILE,
-    icon: User
-  },
-  {
-    title: "Settings",
-    href: AppRoutes.DASHBOARD.SETTINGS,
-    icon: Settings
-  }
-] as const
+import { cn } from '@/lib/utils'
+import { usePathname } from 'next/navigation'
+import { useApp } from '@/contexts/app-context'
+import { SIDEBAR_CONFIG } from './config'
+import { NavigationSection } from './navigation-section'
+import { CollapseToggle } from './collapse-toggle'
 
 export function Sidebar() {
   const pathname = usePathname()
-  const {isCollapsed, isMobileSidebarOpen, toggleSidebar, closeMobileSidebar} = useApp()
-  
+  const { isCollapsed, isMobileSidebarOpen, toggleSidebar, closeMobileSidebar } = useApp()
+
   const sidebarWidth = isCollapsed ? SIDEBAR_CONFIG.COLLAPSED_WIDTH : SIDEBAR_CONFIG.EXPANDED_WIDTH
-  
+
   return (
     <>
+      {/* Mobile overlay */}
       <button
         type="button"
         className={cn(
-          "fixed inset-0 top-16 z-30 bg-black/40 backdrop-blur-[1px] md:hidden",
-          "transition-opacity duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
-          isMobileSidebarOpen ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
+          'fixed inset-0 top-16 z-30 bg-black/40 backdrop-blur-[1px] md:hidden',
+          'transition-opacity duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]',
+          isMobileSidebarOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
         )}
         onClick={closeMobileSidebar}
         aria-label="Close sidebar"
       />
 
-      <div className={cn(
-        `fixed ${SIDEBAR_CONFIG.TOP_OFFSET} left-0 ${SIDEBAR_CONFIG.HEIGHT} border-r bg-background z-40`,
-        "w-64 md:hidden overflow-hidden will-change-transform",
-        "transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
-        isMobileSidebarOpen ? "translate-x-0" : "-translate-x-full"
-      )}>
-        <NavigationSection
-          pathname={pathname}
-          isCollapsed={false}
-          onItemSelect={closeMobileSidebar}
-        />
+      {/* Mobile sidebar */}
+      <div
+        className={cn(
+          `fixed ${SIDEBAR_CONFIG.TOP_OFFSET} left-0 ${SIDEBAR_CONFIG.HEIGHT} border-r bg-background z-40`,
+          'w-64 md:hidden overflow-hidden will-change-transform',
+          'transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]',
+          isMobileSidebarOpen ? 'translate-x-0' : '-translate-x-full'
+        )}
+      >
+        <NavigationSection pathname={pathname} isCollapsed={false} onItemSelect={closeMobileSidebar} />
       </div>
 
-      <div className={cn(
-        `fixed ${SIDEBAR_CONFIG.TOP_OFFSET} left-0 ${SIDEBAR_CONFIG.HEIGHT} border-r bg-background`,
-        "transition-all duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] md:flex flex-col hidden overflow-hidden",
-        sidebarWidth
-      )}>
-        <NavigationSection
-          pathname={pathname}
-          isCollapsed={isCollapsed}
-        />
-        <CollapseToggleSection
-          isCollapsed={isCollapsed}
-          onToggle={toggleSidebar}
-        />
+      {/* Desktop sidebar */}
+      <div
+        className={cn(
+          `fixed ${SIDEBAR_CONFIG.TOP_OFFSET} left-0 ${SIDEBAR_CONFIG.HEIGHT} border-r bg-background`,
+          'transition-all duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] md:flex flex-col hidden overflow-hidden',
+          sidebarWidth
+        )}
+      >
+        <NavigationSection pathname={pathname} isCollapsed={isCollapsed} />
+        <CollapseToggle isCollapsed={isCollapsed} onToggle={toggleSidebar} />
       </div>
     </>
-  )
-}
-
-interface NavigationSectionProps {
-  pathname: string
-  isCollapsed: boolean
-  onItemSelect?: () => void
-}
-
-function NavigationSection({pathname, isCollapsed, onItemSelect}: NavigationSectionProps) {
-  return (
-    <div className="flex-1 space-y-4 py-4">
-      <div className="px-3 py-2">
-        <nav className="space-y-1">
-          {SIDEBAR_ITEMS.map((item) => (
-            <NavigationItem
-              key={item.href}
-              item={item}
-              isActive={pathname === item.href}
-              isCollapsed={isCollapsed}
-              onItemSelect={onItemSelect}
-            />
-          ))}
-        </nav>
-      </div>
-    </div>
-  )
-}
-
-interface NavigationItemProps {
-  item: typeof SIDEBAR_ITEMS[number]
-  isActive: boolean
-  isCollapsed: boolean
-  onItemSelect?: () => void
-}
-
-function NavigationItem({item, isActive, isCollapsed, onItemSelect}: NavigationItemProps) {
-  const IconComponent = item.icon
-  
-  return (
-    <TooltipProvider delayDuration={0}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            asChild
-            variant={isActive ? "secondary" : "ghost"}
-            className={cn(
-              "w-full justify-start overflow-hidden transition-all duration-200",
-              "hover:translate-x-0.5 hover:bg-muted/80",
-              isActive && "bg-muted",
-              isCollapsed && "justify-center px-2"
-            )}
-          >
-            <Link href={item.href} onClick={onItemSelect}>
-              <IconComponent className={cn("h-4 w-4", !isCollapsed && "mr-2")}/>
-              <span
-                className={cn(
-                  "truncate whitespace-nowrap transition-all duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
-                  isCollapsed ? "max-w-0 opacity-0 translate-x-1" : "max-w-[140px] opacity-100 translate-x-0"
-                )}
-              >
-                {item.title}
-              </span>
-            </Link>
-          </Button>
-        </TooltipTrigger>
-        {isCollapsed && (
-          <TooltipContent side="right" className="pointer-events-none">
-            {item.title}
-          </TooltipContent>
-        )}
-      </Tooltip>
-    </TooltipProvider>
-  )
-}
-
-interface CollapseToggleSectionProps {
-  isCollapsed: boolean
-  onToggle: () => void
-}
-
-function CollapseToggleSection({isCollapsed, onToggle}: CollapseToggleSectionProps) {
-  const tooltipText = isCollapsed ? "Expand sidebar" : "Collapse sidebar"
-  
-  return (
-    <div className="p-1 border-t">
-      <TooltipProvider delayDuration={0}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="w-full flex items-center justify-center transition-all duration-300 ease-out hover:bg-muted/70"
-              onClick={onToggle}
-            >
-              <ChevronLeft
-                className={cn("h-4 w-4 transition-transform", isCollapsed && "rotate-180")}
-              />
-              <span
-                className={cn(
-                  "ml-2 whitespace-nowrap overflow-hidden transition-all duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
-                  isCollapsed ? "max-w-0 opacity-0" : "max-w-[160px] opacity-100"
-                )}
-              >
-                {tooltipText}
-              </span>
-            </Button>
-          </TooltipTrigger>
-          {isCollapsed && (
-            <TooltipContent side="right" className="pointer-events-none">
-              {tooltipText}
-            </TooltipContent>
-          )}
-        </Tooltip>
-      </TooltipProvider>
-    </div>
   )
 }

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,12 @@
+import { cn } from '@/lib/utils'
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('animate-pulse rounded-md bg-muted', className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/components/ui/user-avatar.tsx
+++ b/src/components/ui/user-avatar.tsx
@@ -1,0 +1,48 @@
+import Image from 'next/image'
+import { cn } from '@/lib/utils'
+
+type AvatarSize = 'sm' | 'md' | 'lg' | 'xl'
+
+type UserAvatarProps = {
+  src?: string | null
+  name: string
+  size?: AvatarSize
+  className?: string
+}
+
+const SIZE_CLASSES: Record<AvatarSize, string> = {
+  sm: 'h-6 w-6 text-xs',
+  md: 'h-8 w-8 text-sm',
+  lg: 'h-10 w-10 text-base',
+  xl: 'h-16 w-16 text-xl',
+}
+
+const SIZE_PX: Record<AvatarSize, number> = {
+  sm: 24,
+  md: 32,
+  lg: 40,
+  xl: 64,
+}
+
+export function UserAvatar({ src, name, size = 'md', className }: UserAvatarProps) {
+  const initial = name.trim()[0]?.toUpperCase() ?? 'U'
+  const px = SIZE_PX[size]
+
+  return (
+    <div className={cn('rounded-full shrink-0 overflow-hidden', SIZE_CLASSES[size], className)}>
+      {src ? (
+        <Image
+          src={src}
+          alt={name}
+          width={px}
+          height={px}
+          className="h-full w-full object-cover"
+        />
+      ) : (
+        <div className="h-full w-full flex items-center justify-center bg-zinc-600">
+          <span className="text-white font-medium leading-none select-none">{initial}</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -9,7 +9,6 @@ export const AppRoutes = {
     HOME: '/',
     PROJECTS: '/projects',
     TASKS: '/tasks',
-    PROFILE: '/profile',
     SETTINGS: '/settings',
   },
 } as const

--- a/src/contexts/app-context.tsx
+++ b/src/contexts/app-context.tsx
@@ -3,10 +3,8 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
 
 interface AppContextType {
-  theme: 'light' | 'dark' | 'system'
   isCollapsed: boolean
   isMobileSidebarOpen: boolean
-  setTheme: (theme: 'light' | 'dark' | 'system') => void
   toggleSidebar: () => void
   toggleMobileSidebar: () => void
   closeMobileSidebar: () => void
@@ -14,25 +12,16 @@ interface AppContextType {
 
 const AppContext = createContext<AppContextType | undefined>(undefined)
 
-export function AppProvider({children}: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('system')
+export function AppProvider({ children }: { children: React.ReactNode }) {
   const [isCollapsed, setIsCollapsed] = useState(false)
+  const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
   const [mounted, setMounted] = useState(false)
 
-  const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
-
   useEffect(() => {
-    const storedTheme = localStorage.getItem('theme') as 'light' | 'dark' | 'system' | null
-    if (storedTheme) setTheme(storedTheme)
     const storedCollapsed = localStorage.getItem('sidebarCollapsed')
     if (storedCollapsed === 'true') setIsCollapsed(true)
     setMounted(true)
   }, [])
-
-  useEffect(() => {
-    if (!mounted) return
-    localStorage.setItem('theme', theme)
-  }, [theme, mounted])
 
   useEffect(() => {
     if (!mounted) return
@@ -46,21 +35,19 @@ export function AppProvider({children}: { children: React.ReactNode }) {
       document.body.style.overflow = ''
     }
   }, [isMobileSidebarOpen])
-  
+
   const toggleSidebar = () => setIsCollapsed(prev => !prev)
   const toggleMobileSidebar = () => setIsMobileSidebarOpen(prev => !prev)
   const closeMobileSidebar = () => setIsMobileSidebarOpen(false)
-  
+
   return (
     <AppContext.Provider
       value={{
-        theme,
         isCollapsed,
         isMobileSidebarOpen,
-        setTheme,
         toggleSidebar,
         toggleMobileSidebar,
-        closeMobileSidebar
+        closeMobileSidebar,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary

- **Profile Settings**: name edit with `updateProfile` server action (Zod validation), read-only email, avatar display; session refresh via NextAuth `update()` after name change
- **UserAvatar component**: reusable avatar with image or `bg-zinc-600` initial fallback; supports sm/md/lg/xl sizes
- **Header**: replaced notification bell with `ThemeToggle`; avatar skeleton during session loading
- **Sidebar refactor**: split into subcomponents (`navigation-item`, `navigation-section`, `collapse-toggle`, `config`); Settings moved to bottom with separator; fixed icon offset when collapsed (`gap-0` override)
- **Theme Settings**: light/dark/system selector in Settings page; persisted via `next-themes`
- **Loading skeletons**: `Skeleton` component + `loading.tsx` per route (overview, projects, tasks)
- **Charts**: custom tooltip for Tasks by Status with correct per-bar color indicator; removed grey hover cursor; `hideLabel` on Priority Distribution tooltip; renamed to "Tasks by Priority"

## Test plan

- [ ] Profile settings: edit name, save, confirm session updates without re-login
- [ ] Avatar displays correctly for Google OAuth (image) and email/password (initial fallback)
- [ ] Sidebar collapses/expands; state persists on reload; no hydration errors
- [ ] Settings appears at bottom of sidebar with separator
- [ ] Theme toggle in header and settings page; preference persists across reload
- [ ] Loading skeletons appear on slow network for overview, projects, tasks
- [ ] Tasks by Status tooltip shows correct color per bar; no grey hover
- [ ] Priority Distribution tooltip shows no "Tasks" header label